### PR TITLE
Scale sprites and collisions for player and enemies

### DIFF
--- a/enemies/enemy_square/enemy_square.tscn
+++ b/enemies/enemy_square/enemy_square.tscn
@@ -10,7 +10,9 @@ size = Vector2(124, 124)
 script = ExtResource("1_4o1bb")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
+scale = Vector2(0.5, 0.5)
 texture = ExtResource("2_1ihwm")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+scale = Vector2(0.5, 0.5)
 shape = SubResource("RectangleShape2D_w18jr")

--- a/enemies/enemy_triangle/enemy_triangle.tscn
+++ b/enemies/enemy_triangle/enemy_triangle.tscn
@@ -7,8 +7,10 @@
 script = ExtResource("1_xpeg6")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
+scale = Vector2(0.5, 0.5)
 texture = ExtResource("1_xrbw8")
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="."]
+scale = Vector2(0.5, 0.5)
 build_mode = 1
 polygon = PackedVector2Array(-64, -51, -38, -51, 40, -12, 40, 13, -38, 51, -64, 51)

--- a/player/player.tscn
+++ b/player/player.tscn
@@ -10,7 +10,9 @@ radius = 62.0081
 script = ExtResource("1_6bqpg")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
+scale = Vector2(0.5, 0.5)
 texture = ExtResource("2_hrn4e")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+scale = Vector2(0.5, 0.5)
 shape = SubResource("CircleShape2D_ax1ll")


### PR DESCRIPTION
The scale of the sprite and collision nodes for characters (player, enemy_square and enemy_triangle) has been reduced to 0,5. Prior to this adjustment, the characters appeared disproportionately large, which not only affected the visual harmony but also had a slight negative impact on the overall user experience.